### PR TITLE
Disable safety timer in `PMICClass::disableWatchdog`

### DIFF
--- a/src/BQ24195.cpp
+++ b/src/BQ24195.cpp
@@ -770,7 +770,7 @@ bool PMICClass::disableWatchdog(void) {
         return 0;
     }
 
-    return writeRegister(CHARGE_TIMER_CONTROL_REGISTER, (DATA & 0b11001110));
+    return writeRegister(CHARGE_TIMER_CONTROL_REGISTER, (DATA & 0b11000110));
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Creating a Pull request regarding issue 11
Changed the code as there was some typo's in the code
https://github.com/arduino-libraries/Arduino_BQ24195/issues/11