### PR TITLE
Add Nano 33 IoT to CI build.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -43,6 +43,9 @@ jobs:
           - fqbn: arduino:samd:mkrvidor4000
             platforms: |
               - name: arduino:samd
+          - fqbn: arduino:samd:nano_33_iot
+            platforms: |
+              - name: arduino:samd
           - fqbn: arduino:mbed_portenta:envie_m7
             platforms: |
               - name: arduino:mbed_portenta


### PR DESCRIPTION
Required since the Nano Motor Carrier contains a BQ24195.