### PR TITLE
Added FastChargeTimer Setting (get and set)

### DIFF
--- a/src/BQ24195.h
+++ b/src/BQ24195.h
@@ -87,7 +87,7 @@ class PMICClass {
     // Charge Timer Control Register
     bool disableWatchdog(void);
 		float getFastChargeTimerSetting();
-		bool setFastChargeTimerSetting(float hours);
+		bool setFastChargeTimerSetting(float const hours);
 
     // Misc Operation Control Register
     bool enableDPDM(void);

--- a/src/BQ24195.h
+++ b/src/BQ24195.h
@@ -86,6 +86,8 @@ class PMICClass {
 
     // Charge Timer Control Register
     bool disableWatchdog(void);
+		float getFastChargeTimerSetting();
+		bool setFastChargeTimerSetting(float hours);
 
     // Misc Operation Control Register
     bool enableDPDM(void);


### PR DESCRIPTION
I have a project where a 10,000mAh battery is charging using Arduino 1010 and related platforms. Thermal constraints restrict the effective charging current to about 500mA which needs more than 8h (the default) to charge, yielding a charge fault (blinking CHRG LED). The simplest way to fix this was to add a setting for the charge timer which can be set up to 20h. The attached commit implements this - the set function rounds up since only four values are supported.

(I'll still try adding a heatsink to increase charging current, however even at 1A the charging time of 8h is too small)

I hereby contribute this code under the same license as the original code, or public domain if more convenient.

Best,
  Alex