### PR TITLE
Fix setInputCurrentLimit() for currents between 0.9 A and 1.2 A.

### DIFF
--- a/src/BQ24195.cpp
+++ b/src/BQ24195.cpp
@@ -347,7 +347,7 @@ bool PMICClass::setInputCurrentLimit(float current) {
     if (current >= 0.5) {
         current_val = CURRENT_LIM_500;
     }
-    if (current >= CURRENT_LIM_900) {
+    if (current >= 0.9) {
         current_val = CURRENT_LIM_900;
     }
     if (current >= 1.2) {


### PR DESCRIPTION
Fix copy & paste error for `current >= 0.9`