### PR TITLE
BugFix: Issue #53 - Fix set setInputCurrentLimit() for 900mA.

### DIFF
--- a/src/BQ24195.cpp
+++ b/src/BQ24195.cpp
@@ -347,7 +347,7 @@ bool PMICClass::setInputCurrentLimit(float current) {
     if (current >= 0.5) {
         current_val = CURRENT_LIM_500;
     }
-    if (current >= CURRENT_LIM_900) {
+    if (current >= 0.9) {
         current_val = CURRENT_LIM_900;
     }
     if (current >= 1.2) {


### PR DESCRIPTION
Bug: Setting the input current limit to 900mA does not work
Issue [#53](https://github.com/arduino-libraries/Arduino_BQ24195/issues/53)

Summary: Setting the input current limit to 900mA does not work.

File: BQ24195.cpp
Function: bool PMICClass::setInputCurrentLimit(float current)

Problem: There is a typo preventing correct operation:

Line 350:
   if (current >= CURRENT_LIM_900) { current_val = CURRENT_LIM_900; }

should be:
if (current >= 0.9) { current_val = CURRENT_LIM_900; }

