### PR TITLE
[BREAKING] Fix inverted logic in canRunOnBattery #38

### DIFF
--- a/examples/BatteryCharger/BatteryCharger.ino
+++ b/examples/BatteryCharger/BatteryCharger.ino
@@ -59,9 +59,9 @@ void loop() {
   if (!PMIC.enableCharge()) {
     Serial.println("Error enabling Charge mode");
   }
-  // canRunOnBattery() returns true if the battery voltage is < the minimum
+  // canRunOnBattery() returns true if the battery voltage is > the minimum
   // systems voltage
-  if (PMIC.canRunOnBattery()) {
+  if (!PMIC.canRunOnBattery()) {
     // loop until charge is done
     while (PMIC.chargeStatus() != CHARGE_TERMINATION_DONE) {
       delay(1000);

--- a/examples/BatteryChargerInterrupt/BatteryChargerInterrupt.ino
+++ b/examples/BatteryChargerInterrupt/BatteryChargerInterrupt.ino
@@ -69,9 +69,9 @@ void loop() {
       Serial.println("Error enabling Charge mode");
     }
 
-    // canRunOnBattery() returns true if the battery voltage is < the minimum
+    // canRunOnBattery() returns true if the battery voltage is > the minimum
     // systems voltage
-    if (PMIC.canRunOnBattery()) {
+    if (!PMIC.canRunOnBattery()) {
 
       // loop until charge is done
       if (PMIC.chargeStatus() != CHARGE_TERMINATION_DONE) {

--- a/src/BQ24195.cpp
+++ b/src/BQ24195.cpp
@@ -1062,11 +1062,13 @@ bool PMICClass::isHot(void) {
 }
 
 /*******************************************************************************
- * Function Name  : getVsysStat
+ * Function Name  : canRunOnBattery
  * Description    : Check if the battery voltage is lower than the input
-                    system voltage limit
+                    system voltage limit. Does not check other conditions, e.g.
+                    if battery is connected
+                    Notice the inversion of the register flag
  * Input          : NONE
- * Return         : 0 if V_BAT > V_SYS_MIN, 1 if V_BAT < V_SYS_MIN
+ * Return         : true if V_BAT > V_SYS_MIN, false if V_BAT < V_SYS_MIN
  *******************************************************************************/
 bool PMICClass::canRunOnBattery() {
 
@@ -1074,13 +1076,16 @@ bool PMICClass::canRunOnBattery() {
     DATA = readRegister(SYSTEM_STATUS_REGISTER);
 
     if (DATA == -1) {
+        // Pessimistically assume an issue with battery too
         return 0;
     }
 
-    if(DATA & 0x01) {
-        return 1;
+    if (DATA & 0x01) {
+        // PMIC is in VSYSMIN regulation, which means the voltage is too low
+        return 0;
     }
-    return 0;
+
+    return 1;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Double checked the [datasheet](https://www.ti.com/lit/ds/symlink/bq24195.pdf) and tested with the MKR1010 to confirm.
The examples are updated accordingly.

Despite this being a bug, given its been years, I tend to consider this a breaking change.
I would appreciate help making this as prominent as we can for the folks who just dealt with the erroneous inversion in their code already.